### PR TITLE
fix: word-wrap of moderators card text and title; fix sortDropDown me…

### DIFF
--- a/src/common/components/sort-dropdown/index.tsx
+++ b/src/common/components/sort-dropdown/index.tsx
@@ -119,7 +119,7 @@ const SortDropdown: React.FC<Properties> = ({
 					</IconButton>
 				)}
 				{!isIconButton && (
-					<>
+					<div className={styles["dropdown_trigger_wrapp"]}>
 						<div
 							className={clsx(styles["dropdown_trigger"], {
 								[styles["open"]]: isOpen,
@@ -135,6 +135,7 @@ const SortDropdown: React.FC<Properties> = ({
 								<ArrowDown className={styles["dropdown_icon"]} />
 							)}
 						</div>
+
 						{isWithCleaner && (
 							<IconButton
 								className={clsx(
@@ -146,7 +147,7 @@ const SortDropdown: React.FC<Properties> = ({
 								<Icon name={IconName.CLOSE_CIRCLE} />
 							</IconButton>
 						)}
-					</>
+					</div>
 				)}
 				{isOpen && !isDisabled && (
 					<div

--- a/src/common/components/sort-dropdown/styles.module.scss
+++ b/src/common/components/sort-dropdown/styles.module.scss
@@ -25,10 +25,6 @@
 .dropdown_container {
 	overflow: visible;
 	position: relative;
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	gap: 16px;
 }
 
 .sort__button {
@@ -49,6 +45,12 @@
 .sort__button_icon:focus,
 .sort__button_icon:active {
 	color: var(--color-black);
+}
+
+.dropdown_trigger_wrapp {
+	width: 100%;
+	display: flex;
+	gap: 16px;
 }
 
 .dropdown_trigger {

--- a/src/pages/course-details-page/components/main-content/components/reviews-bar/components/reviews-list/components/review/components/review-main/index.tsx
+++ b/src/pages/course-details-page/components/main-content/components/reviews-bar/components/reviews-list/components/review/components/review-main/index.tsx
@@ -37,7 +37,7 @@ const ReviewMain: React.FC<ReviewMainProperties> = ({ text }) => {
 	};
 
 	defineTextHeight();
-	
+
 	return (
 		<div className={styles["review__main"]}>
 			<section className={styles["review__text"]} ref={textRef}>

--- a/src/pages/course-details-page/components/main-content/components/reviews-bar/components/reviews-list/index.tsx
+++ b/src/pages/course-details-page/components/main-content/components/reviews-bar/components/reviews-list/index.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 
-import styles from "./styles.module.scss";
-
 import { Review } from "./components/review";
+import styles from "./styles.module.scss";
 
 const ReviewsList: React.FC = () => {
 	return (

--- a/src/pages/course-details-page/components/main-content/components/reviews-bar/components/reviews-stats/index.tsx
+++ b/src/pages/course-details-page/components/main-content/components/reviews-bar/components/reviews-stats/index.tsx
@@ -3,13 +3,13 @@ import React, { useEffect, useState } from "react";
 import { Button, StarRating } from "~/common/components";
 import { ScreenBreakpoints } from "~/common/constants/index";
 import { ButtonSize, ButtonVariant, RatingSize } from "~/common/enums";
+import { useGetScreenWidth } from "~/common/hooks";
 import { type ReviewsStats } from "~/common/types";
 import { useGetCourseByIdQuery } from "~/redux/courses/courses-api";
 
 import { RatingBar } from "./components/rating-bar";
 import { StatsBar } from "./components/stats-bar";
 import styles from "./styles.module.scss";
-import { useGetScreenWidth } from "~/common/hooks";
 
 type ReviewsStatsProperties = {
 	stats: ReviewsStats;

--- a/src/pages/moderators-page/components/main-content/components/filter-section/styles.module.scss
+++ b/src/pages/moderators-page/components/main-content/components/filter-section/styles.module.scss
@@ -12,7 +12,7 @@
 		padding: 0 20px 44px;
 	}
 	.fitters_block__category {
-		@media (min-width: 480px) and (max-width: 1000px) {
+		@media (min-width: 481px) and (max-width: 1000px) {
 			width: 50%;
 		}
 		.fitters_block__category_title {
@@ -27,7 +27,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 12px;
-		@media (min-width: 480px) and (max-width: 1000px) {
+		@media (min-width: 481px) and (max-width: 1000px) {
 			width: 50%;
 		}
 		.fitters_block__sort_title {

--- a/src/pages/moderators-page/components/main-content/components/review-card/styles.module.scss
+++ b/src/pages/moderators-page/components/main-content/components/review-card/styles.module.scss
@@ -167,7 +167,6 @@
 .title {
 	position: relative;
 	display: flex;
-
 	gap: 8px;
 	padding-bottom: 28px;
 
@@ -196,6 +195,10 @@
 		font-size: var(--font-size-title-h4);
 		line-height: 130%;
 		color: var(--color-grey-950);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		text-align: left;
 
 		@include tablet {
 			font-weight: var(--font-weight-extra-bold);
@@ -266,6 +269,7 @@
 		line-height: 140%;
 		color: var(--color-grey-950);
 		margin-bottom: 6px;
+		word-break: break-all;
 
 		&_button {
 			font-weight: var(--font-weight-bold);
@@ -322,6 +326,7 @@
 
 .rating_block > span:last-child {
 	line-height: 140%;
+	font-weight: var(--font-weight-bold);
 }
 
 .rating_block .stars_block {


### PR DESCRIPTION
fix: word-wrap of moderators card text and title; fix sortDropDown menu position in mobile
![image](https://github.com/user-attachments/assets/1dd71c19-1f28-4eea-b4eb-1af76184c981)

![image](https://github.com/user-attachments/assets/6ea84374-9047-4b8e-90be-d355e1e84ee1)
